### PR TITLE
Fix coverage in 2.10 and macro warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 
-script: "sbt clean coverage test coverageReport"
+script: "sbt clean coverageEnable test coverageReport"
 
 scala:
    - 2.10.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 
-script: "sbt clean coverageEnable test coverageReport"
+script: "sbt ++$TRAVIS_SCALA_VERSION clean coverageEnable test coverageReport"
 
 scala:
    - 2.10.6

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ It uses:
 * Scalatest for unit tests
 * Scoverage 1.3.5
 
+To run:
+
+```
+sbt clean coverage test  ++2.10.6 ";set coverageEnabled := true;clean;test"
+```
 
 ## License
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -34,3 +34,6 @@ coverageHighlighting := true
 publishArtifact in Test := false
 
 parallelExecution in Test := false
+
+addCommandAlias("coverageEnable", "set coverageEnabled := true")
+addCommandAlias("coverageDisable", "set coverageEnabled := false")

--- a/build.sbt
+++ b/build.sbt
@@ -10,28 +10,26 @@ crossScalaVersions := Seq("2.11.8", "2.10.6")
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 
-scalacOptions ++= Seq("-unchecked", "-deprecation")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 scalacOptions in (Compile, doc) ++= Seq("-unchecked", "-deprecation", "-diagrams", "-implicits", "-skip-packages", "samples")
 
 libraryDependencies ++= Seq(
-  "commons-io"                 % "commons-io"              % "2.4",
+  "commons-io"                 %  "commons-io"             % "2.4",
   "com.typesafe.akka"          %% "akka-actor"             % "2.3.2",
   "com.typesafe.akka"          %% "akka-actor-tests"       % "2.3.2",
-  "com.typesafe.scala-logging" %% "scala-logging-slf4j"    % "2.1.2",
-  "org.scalatest"              %% "scalatest"              % "2.2.1"            % "test"
+  "org.typelevel"              %% "macro-compat"           % "1.1.1",
+  "org.scala-lang"             %  "scala-compiler"         % scalaVersion.value % "provided",
+  "org.scala-lang"             %  "scala-reflect"          % scalaVersion.value % "provided",
+  "org.scalatest"              %% "scalatest"              % "2.2.1"            % "test",
+  compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
 coverageMinimum := 70
 
 coverageFailOnMinimum := false
 
-coverageHighlighting := {
-  if (scalaBinaryVersion.value == "2.11")
-    true
-  else
-    false
-}
+coverageHighlighting := true
 
 publishArtifact in Test := false
 

--- a/src/main/scala/com/sksamuel/scoverage/samples/ClientActor.scala
+++ b/src/main/scala/com/sksamuel/scoverage/samples/ClientActor.scala
@@ -4,6 +4,7 @@ import akka.actor.{ActorRef, Actor}
 import scala.util.Random
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.postfixOps
 
 /** @author Stephen Samuel */
 class ClientActor(priceEngine: ActorRef, orderEngine: ActorRef) extends Actor {

--- a/src/main/scala/com/sksamuel/scoverage/samples/CreditEngine.scala
+++ b/src/main/scala/com/sksamuel/scoverage/samples/CreditEngine.scala
@@ -1,20 +1,18 @@
 package com.sksamuel.scoverage.samples
 
 import akka.actor.Actor
-import com.typesafe.scalalogging.slf4j.StrictLogging
 
 /** @author Stephen Samuel */
-class CreditEngine extends Actor with StrictLogging {
-
+class CreditEngine extends Actor {
   val MaxCredit = BigDecimal.valueOf(2000)
 
   def receive = {
     case req: CreditRequest =>
-      logger.debug("Received a credit request")
+      println("Received a credit request")
       if (req.amount < MaxCredit) sender ! CreditApprove(req.req, req.amount, req.client)
       else sender ! CreditReject(req.req, req.client)
       if (System.currentTimeMillis < 0) {
-        logger.debug("Don't want to see this invoked") // should not see this covered
+        println("Don't want to see this invoked") // should not see this covered
       }
   }
 }

--- a/src/main/scala/com/sksamuel/scoverage/samples/Debugger.scala
+++ b/src/main/scala/com/sksamuel/scoverage/samples/Debugger.scala
@@ -1,17 +1,23 @@
 package com.sksamuel.scoverage.samples
 
 import scala.language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox
+import macrocompat.bundle
 
 /** @author Stephen Samuel */
 object Debugger {
 
-  def debug(params: Any*) = macro debugImpl
+  def debug(params: Any*): Unit = macro DebuggerMacros.debugImpl
+}
 
+@bundle
+class DebuggerMacros(val c: whitebox.Context) {
+  import c.universe._
   /**
    * Implementation of the debug macro
    */
-  def debugImpl(c: Context)(params: c.Expr[Any]*) = {
+
+  def debugImpl(params: c.Expr[Any]*): c.Expr[Unit] = {
     import c.universe._
 
     val trees = params map {

--- a/src/main/scala/com/sksamuel/scoverage/samples/Futures.scala
+++ b/src/main/scala/com/sksamuel/scoverage/samples/Futures.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.scoverage.samples
 
 import scala.concurrent.{Promise, Future, ExecutionContext}
+import scala.language.implicitConversions
 
 /** @author Stephen Samuel */
 class Futures {

--- a/src/main/scala/com/sksamuel/scoverage/samples/PriceEngine.scala
+++ b/src/main/scala/com/sksamuel/scoverage/samples/PriceEngine.scala
@@ -3,6 +3,7 @@ package com.sksamuel.scoverage.samples
 import akka.actor.{Cancellable, Actor}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.postfixOps
 
 /**
  * Produces quotes on a regular basis for all instruments and

--- a/src/test/scala/com/sksamuel/scoverage/samples/ClientActorTest.scala
+++ b/src/test/scala/com/sksamuel/scoverage/samples/ClientActorTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.{OneInstancePerTest, FlatSpec}
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.TestProbe
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 /** @author Stephen Samuel */
 class ClientActorTest extends FlatSpec with OneInstancePerTest {

--- a/src/test/scala/com/sksamuel/scoverage/samples/CreditEngineTest.scala
+++ b/src/test/scala/com/sksamuel/scoverage/samples/CreditEngineTest.scala
@@ -5,6 +5,7 @@ import akka.actor.{ActorSystem, Props}
 import akka.pattern.{Patterns => TestImportAliasPatterns}
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.language.postfixOps
 import akka.testkit.TestProbe
 
 /** @author Stephen Samuel */


### PR DESCRIPTION
- Added `macro-compat` so that macros are correct for 2.10 and 2.11 and no warnings
- Removed `scalalogging` as the latest 2.10 version was 2.10.4 and we know we require 2.10.5+ . This is a known issue - https://github.com/typesafehub/scala-logging/issues/30 - and has not been addressed. I see little point using this library as we know it will fail. 
- Added `coverageEnable` and `coverageDisable` command alias's, that may in fact be useful additions to the sbt-plugin
