### PR TITLE
Fix `upickle` problem

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ libraryDependencies ++= Seq(
   "commons-io"             %  "commons-io"    % "2.11.0",
   "com.typesafe.akka"      %% "akka-actor"    % "2.6.20",
   "com.typesafe.akka"      %% "akka-testkit"  % "2.6.20" % "test",
-  "org.scalatest"          %% "scalatest"     % "3.2.14" % "test"
+  "org.scalatest"          %% "scalatest"     % "3.2.14" % "test",
+  "com.lihaoyi"            %% "upickle"       % "2.0.0"
 )
 
 import org.scoverage.coveralls.Imports.CoverallsKeys._

--- a/src/main/scala/org/scoverage/samples/CustomPicklers.scala
+++ b/src/main/scala/org/scoverage/samples/CustomPicklers.scala
@@ -1,0 +1,25 @@
+package org.scoverage.samples
+
+import upickle._
+
+/**
+  * Json boilerplate.
+  * - Parse null and missing objects into scala Options
+  */
+object CustomPicklers {
+
+  object OptionPickler extends upickle.AttributeTagged {
+    override implicit def OptionWriter[T: Writer]: Writer[Option[T]] =
+      implicitly[Writer[T]].comap[Option[T]] {
+        case None    => null.asInstanceOf[T]
+        case Some(x) => x
+      }
+
+    override implicit def OptionReader[T: Reader]: Reader[Option[T]] = {
+      new Reader.Delegate[Any, Option[T]](implicitly[Reader[T]].map(Some(_))) {
+        override def visitNull(index: Int) = None
+      }
+    }
+  }
+
+}

--- a/src/main/scala/org/scoverage/samples/UpickleStuff.scala
+++ b/src/main/scala/org/scoverage/samples/UpickleStuff.scala
@@ -1,0 +1,16 @@
+package org.scoverage.samples
+
+import org.scoverage.samples.CustomPicklers.OptionPickler.{
+  ReadWriter => RW,
+  macroRW
+}
+
+object UpickleStuff {
+  case class Person(
+      name: String
+  )
+
+  object Person {
+    implicit val rw: RW[Person] = macroRW
+  }
+}


### PR DESCRIPTION
```
[error] (coverageReport) No source root found for '/home/roland/Development/Home/sbt-scoverage-samples/implicits/src-3/upickle/implicits/CaseClassReader.scala' (source roots: '/home/roland/Development/Home/sbt-scoverage-samples/src/main/scala/')
```
This is not a problem with `upickle`. `upickle` just make the problem show up.

We are still investigating what the problem is ...

```
~/Development/Home/sbt-scoverage-samples (tom-roland/testing-with-upickle ✔) ᐅ sbt
[info] welcome to sbt 1.7.1 (Oracle Corporation Java 18)
[info] loading settings for project sbt-scoverage-samples-build-build-build from metals.sbt ...
[info] loading project definition from /home/roland/Development/Home/sbt-scoverage-samples/project/project/project
[info] loading settings for project sbt-scoverage-samples-build-build from metals.sbt ...
[info] loading project definition from /home/roland/Development/Home/sbt-scoverage-samples/project/project
[success] Generated .bloop/sbt-scoverage-samples-build-build.json
[success] Total time: 0 s, completed 13 Nov 2022, 16:04:53
[info] loading settings for project sbt-scoverage-samples-build from metals.sbt,plugins.sbt ...
[info] loading project definition from /home/roland/Development/Home/sbt-scoverage-samples/project
[success] Generated .bloop/sbt-scoverage-samples-build.json
[success] Total time: 0 s, completed 13 Nov 2022, 16:04:53
[info] loading settings for project sbt-scoverage-samples from build.sbt ...
[info] set current project to sbt-scoverage-samples (in build file:/home/roland/Development/Home/sbt-scoverage-samples/)
[info] sbt server started at local:///home/roland/.sbt/1.0/server/ea5e97b1e979389b224f/sock
[info] started sbt server
sbt:sbt-scoverage-samples> 
sbt:sbt-scoverage-samples> ++2.13.9
[info] Setting Scala version to 2.13.9 on 1 projects.
[info] Reapplying settings...
[info] set current project to sbt-scoverage-samples (in build file:/home/roland/Development/Home/sbt-scoverage-samples/)
sbt:sbt-scoverage-samples> coverage
[info] Defining ThisBuild / coverageEnabled
[info] The new value will be used by Compile / compile / scalacOptions, libraryDependencies
[info] Reapplying settings...
[info] set current project to sbt-scoverage-samples (in build file:/home/roland/Development/Home/sbt-scoverage-samples/)
sbt:sbt-scoverage-samples> test
[info] compiling 19 Scala sources to /home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/classes ...
[info] scoverage excludedSymbols: List(scala.reflect.api.Exprs.Expr, scala.reflect.api.Trees.Tree, scala.reflect.macros.Universe.Tree)
[info] Cleaning datadir [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/scoverage-data]
[info] Beginning coverage instrumentation
[info] Instrumentation completed [251 statements]
[info] Wrote instrumentation file [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/scoverage-data/scoverage.coverage]
[info] Will write measurement data to [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/scoverage-data]
Received a credit request
Received a credit request
[info] CreditEngineTest:
[info] a credit engine
[info] - should approve amounts under the minimum
[info] - should reject amounts over the min
[info] SimpleObject2Test:
[info] - invoking simpleobject2
[info] FuturesTest:
[info] - futures happy path
[info] PriceEngineTest:
[info] a price engine
[info] - should broadcast on startup
[info] - should stop broadcasting on StopService msg
[info] - should restart broadcasting on StartService message
[info] CharmaxTest:
[info] a char max
[info] - should not crash the XML writer
[info] OrderEngineTest:
[info] an order engine
[info] - should create an order if credit approved
[info] - should reject order if credit denied
[info] - should send a credit request if a quote is available
Sending order request
[info] ClientActorTest:
[info] a client actor
[info] - should ask for a quote
[info] - should send a market order request if ask under minimum
[info] - should not send an order request if ask is over minimum
[info] DefaultArgumentsObjectTest:
[info] DefaultArgumentsObject
[info] - should execute the default block if no arg is given
[info] OrderValidatorTest:
[info] an order validator
[info] - should throw exception
[info] SimpleClassTest:
[info] a SimpleClassTest
[info] - should test 1
[info] Run completed in 4 seconds, 780 milliseconds.
[info] Total number of tests run: 17
[info] Suites: completed 10, aborted 0
[info] Tests: succeeded 17, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 12 s, completed 13 Nov 2022, 16:05:38
sbt:sbt-scoverage-samples> coverageReport
[info] Waiting for measurement data to sync...
[info] Reading scoverage instrumentation [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/scoverage-data/scoverage.coverage]
[info] Reading scoverage measurements...
[info] Generating scoverage reports...
[info] Written Cobertura report [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/coverage-report/cobertura.xml]
[info] Written XML coverage report [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/scoverage-report/scoverage.xml]
[info] Written HTML coverage report [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-2.13/scoverage-report/index.html]
[info] Statement coverage.: 70.12%
[info] Branch coverage....: 60.98%
[info] Coverage reports completed
[error] Coverage is below minimum [60.98% < 70.00%]: Branch:Total
[info] All done. Coverage was stmt=[70.12%] branch=[60.98%]
[success] Total time: 1 s, completed 13 Nov 2022, 16:06:01
sbt:sbt-scoverage-samples> ++3.2.0
[info] Setting Scala version to 3.2.0 on 1 projects.
[info] Reapplying settings...
[info] set current project to sbt-scoverage-samples (in build file:/home/roland/Development/Home/sbt-scoverage-samples/)
sbt:sbt-scoverage-samples> test
Received a credit request
Received a credit request
[info] CreditEngineTest:
[info] a credit engine
[info] - should approve amounts under the minimum
[info] - should reject amounts over the min
[info] SimpleObject2Test:
[info] - invoking simpleobject2
[info] FuturesTest:
[info] - futures happy path
[info] PriceEngineTest:
[info] a price engine
[info] - should broadcast on startup
[info] - should stop broadcasting on StopService msg
[info] - should restart broadcasting on StartService message
[info] CharmaxTest:
[info] a char max
[info] - should not crash the XML writer
[info] OrderEngineTest:
[info] an order engine
[info] - should create an order if credit approved
[info] - should reject order if credit denied
[info] - should send a credit request if a quote is available
Sending order request
[info] ClientActorTest:
[info] a client actor
[info] - should ask for a quote
[info] - should send a market order request if ask under minimum
[info] - should not send an order request if ask is over minimum
[info] DefaultArgumentsObjectTest:
[info] DefaultArgumentsObject
[info] - should execute the default block if no arg is given
[info] OrderValidatorTest:
[info] an order validator
[info] - should throw exception
[info] SimpleClassTest:
[info] a SimpleClassTest
[info] - should test 1
[info] Run completed in 4 seconds, 680 milliseconds.
[info] Total number of tests run: 17
[info] Suites: completed 10, aborted 0
[info] Tests: succeeded 17, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 6 s, completed 13 Nov 2022, 16:06:19
sbt:sbt-scoverage-samples> coverageReport
[info] Waiting for measurement data to sync...
[info] Reading scoverage instrumentation [/home/roland/Development/Home/sbt-scoverage-samples/target/scala-3.2.0/scoverage-data/scoverage.coverage]
[info] Reading scoverage measurements...
[info] Generating scoverage reports...
[error] stack trace is suppressed; run last coverageReport for the full output
[error] (coverageReport) No source root found for '/home/roland/Development/Home/sbt-scoverage-samples/implicits/src-3/upickle/implicits/CaseClassReader.scala' (source roots: '/home/roland/Development/Home/sbt-scoverage-samples/src/main/scala/')
[error] Total time: 1 s, completed 13 Nov 2022, 16:06:22
```